### PR TITLE
Build fixes due to libwnck deprecation

### DIFF
--- a/src/hotcorner.c
+++ b/src/hotcorner.c
@@ -226,9 +226,10 @@ static gint check_hot_corner_action(HotCorner * hotCorner)
 	gdk_device_get_position(device, NULL, &x, &y);
 
 	if (hotCorner->disableWhenFullScreen) {
-		WnckScreen *wnckScreen = wnck_screen_get_default();
-		WnckWindow *activeWindow =
-		    wnck_screen_get_active_window(wnckScreen);
+		//TODO Fix full-screen checkmark
+		WnckHandle *wnckHandle = wnck_handle_new(WNCK_CLIENT_TYPE_APPLICATION);
+		WnckScreen *wnckScreen = wnck_handle_get_default_screen(wnckHandle); //wnck_screen_get_default()
+		WnckWindow *activeWindow = wnck_screen_get_active_window(wnckScreen);
 		if (wnck_window_is_fullscreen(activeWindow)) {
 			return TRUE;
 		}
@@ -282,10 +283,19 @@ static void start_polling_mouse_position(HotCorner * hotCorner)
 
 static HotCorner *hotCorner_new(XfcePanelPlugin * plugin)
 {
-	HotCorner *hotCorner = g_new0(HotCorner, 1);
+	GtkWidget *gtkImage = gtk_image_new();
+	xfce_panel_set_image_from_source(
+		(GtkImage *)gtkImage,
+		HOTCORNER_ICON_NAME,
+		NULL,
+		xfce_panel_plugin_get_icon_size(plugin),
+		gtk_widget_get_scale_factor(GTK_WIDGET (plugin)));
+
+	HotCorner *hotCorner;
+	hotCorner = g_new0(HotCorner, 1);
 	hotCorner->plugin = plugin;
-	hotCorner->icon =
-	    xfce_panel_image_new_from_source(HOTCORNER_ICON_NAME);
+	hotCorner->icon = gtkImage;
+	//xfce_panel_image_new_from_source(HOTCORNER_ICON_NAME);
 	hotCorner->disableWhenFullScreen = TRUE;
 	hotCorner->upperLeftCallback = NULL;
 	hotCorner->lowerLeftCallback = NULL;
@@ -508,11 +518,13 @@ static void on_open_configure_window(XfcePanelPlugin * plugin,
 
 	xfce_panel_plugin_block_menu(plugin);
 	GtkWidget *dialog =
-	    xfce_titled_dialog_new_with_buttons(_("HotCorner"),
+	    //xfce_titled_dialog_new_with_buttons(_("HotCorner"),
+		xfce_titled_dialog_new_with_mixed_buttons(_("HotCorner"),
 			GTK_WINDOW
 			(gtk_widget_get_toplevel
 				 (GTK_WIDGET (hotCorner->plugin))),
 			GTK_DIALOG_DESTROY_WITH_PARENT,
+			_("Close"),
 			_("Close"),
 			GTK_RESPONSE_OK, NULL);
 

--- a/src/hotcorner.c
+++ b/src/hotcorner.c
@@ -228,7 +228,7 @@ static gint check_hot_corner_action(HotCorner * hotCorner)
 	if (hotCorner->disableWhenFullScreen) {
 		//TODO Fix full-screen checkmark
 		WnckHandle *wnckHandle = wnck_handle_new(WNCK_CLIENT_TYPE_APPLICATION);
-		WnckScreen *wnckScreen = wnck_handle_get_default_screen(wnckHandle); //wnck_screen_get_default()
+		WnckScreen *wnckScreen = wnck_handle_get_default_screen(wnckHandle);
 		WnckWindow *activeWindow = wnck_screen_get_active_window(wnckScreen);
 		if (wnck_window_is_fullscreen(activeWindow)) {
 			return TRUE;
@@ -295,7 +295,6 @@ static HotCorner *hotCorner_new(XfcePanelPlugin * plugin)
 	hotCorner = g_new0(HotCorner, 1);
 	hotCorner->plugin = plugin;
 	hotCorner->icon = gtkImage;
-	//xfce_panel_image_new_from_source(HOTCORNER_ICON_NAME);
 	hotCorner->disableWhenFullScreen = TRUE;
 	hotCorner->upperLeftCallback = NULL;
 	hotCorner->lowerLeftCallback = NULL;
@@ -518,7 +517,6 @@ static void on_open_configure_window(XfcePanelPlugin * plugin,
 
 	xfce_panel_plugin_block_menu(plugin);
 	GtkWidget *dialog =
-	    //xfce_titled_dialog_new_with_buttons(_("HotCorner"),
 		xfce_titled_dialog_new_with_mixed_buttons(_("HotCorner"),
 			GTK_WINDOW
 			(gtk_widget_get_toplevel

--- a/src/util.c
+++ b/src/util.c
@@ -48,7 +48,7 @@ void toggle_desktop(int spot __attribute__((unused)),
 		    HotCorner * hotCorner __attribute__((unused)))
 {
 	WnckHandle *wnckHandle = wnck_handle_new(WNCK_CLIENT_TYPE_PAGER);
-	WnckScreen *wnck = wnck_handle_get_default_screen(wnckHandle); //wnck_screen_get_default()
+	WnckScreen *wnck = wnck_handle_get_default_screen(wnckHandle);
 	gboolean is_showing = wnck_screen_get_showing_desktop(wnck);
 
 	wnck_screen_toggle_showing_desktop(wnck, !is_showing);

--- a/src/util.c
+++ b/src/util.c
@@ -16,7 +16,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include<libnotify/notify.h>
+#include <libnotify/notify.h>
 
 #include <libwnck/libwnck.h>
 #include "util.h"
@@ -47,7 +47,8 @@ gboolean is_lower_left(GdkRectangle monitorInfo, gint x, gint y)
 void toggle_desktop(int spot __attribute__((unused)),
 		    HotCorner * hotCorner __attribute__((unused)))
 {
-	WnckScreen *wnck = wnck_screen_get_default();
+	WnckHandle *wnckHandle = wnck_handle_new(WNCK_CLIENT_TYPE_PAGER);
+	WnckScreen *wnck = wnck_handle_get_default_screen(wnckHandle); //wnck_screen_get_default()
 	gboolean is_showing = wnck_screen_get_showing_desktop(wnck);
 
 	wnck_screen_toggle_showing_desktop(wnck, !is_showing);


### PR DESCRIPTION
When building I was receiving errors saying `wnck_screen_get_default` and `xfce_panel_image_new_from_source` are deprecated. I updated hotcorner.c and util.c so now it compiles.

Errors during build were:
```error: 'wnck_screen_get_default' is deprecated: Use 'wnck_handle_get_default_screen' instead [-Werror=deprecated-declarations]```

```error: 'xfce_panel_image_new_from_source' is deprecated: Use gtk_image_new() and xfce_panel_set_image_from_source() instead [-Werror=deprecated-declarations]```

There are no docs for `wnck_handle_get_default_screen` yet, so may need an update later. The "Disable when active window is full screen" checkbox doesn't work, but I am not sure if it was an issue from before.

This is my first pull-request, so glad to change if anything is needed. 